### PR TITLE
wakeup: Use procfs when debugfs is unavailable

### DIFF
--- a/drivers/base/power/wakeup.c
+++ b/drivers/base/power/wakeup.c
@@ -13,12 +13,17 @@
 #include <linux/export.h>
 #include <linux/suspend.h>
 #include <linux/seq_file.h>
-#include <linux/debugfs.h>
 #include <linux/pm_wakeirq.h>
 #include <linux/types.h>
 #include <trace/events/power.h>
 #include <linux/irq.h>
 #include <linux/irqdesc.h>
+
+#ifdef CONFIG_DEBUG_FS
+#include <linux/debugfs.h>
+#else
+#include <linux/proc_fs.h>
+#endif
 
 #include "power.h"
 
@@ -1028,8 +1033,6 @@ void pm_wakep_autosleep_enabled(bool set)
 }
 #endif /* CONFIG_PM_AUTOSLEEP */
 
-static struct dentry *wakeup_sources_stats_dentry;
-
 /**
  * print_wakeup_source_stats - Print wakeup source statistics information.
  * @m: seq_file to print the statistics into.
@@ -1114,11 +1117,21 @@ static const struct file_operations wakeup_sources_stats_fops = {
 	.release = single_release,
 };
 
+#ifdef CONFIG_DEBUG_FS
 static int __init wakeup_sources_debugfs_init(void)
 {
-	wakeup_sources_stats_dentry = debugfs_create_file("wakeup_sources",
-			S_IRUGO, NULL, NULL, &wakeup_sources_stats_fops);
+	debugfs_create_file("wakeup_sources", S_IRUGO, NULL, NULL, &wakeup_sources_stats_fops);
 	return 0;
 }
 
 postcore_initcall(wakeup_sources_debugfs_init);
+
+#else
+static int __init wakelocks_proc_init(void)
+{
+	proc_create("wakelocks", S_IRUGO, NULL, &wakeup_sources_stats_fops);
+	return 0;
+}
+
+postcore_initcall(wakelocks_proc_init);
+#endif


### PR DESCRIPTION
Use "/proc/wakelocks" instead of "/d/wakeup_sources" if debugfs is disabled.

Fixes log spam in "/data/system/dropbox" where the device is unable to read the list of wakelocks, potentially causing system_server process to have high cpu and battery usage.

(based on commit https://github.com/crdroidandroid/android_kernel_oneplus_sm8150/commit/0b579bfdbf07e518f681cd871fd9b02631b52164)